### PR TITLE
Shorten urls and handle invalid tokens

### DIFF
--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -21,6 +21,14 @@ function Item() {
       });
   }, [id]);
 
+  function ShortenUrl(url) {
+    if (!url) {
+      return ""
+    }
+    return ((url.length <= 50) ? 
+      url : url.substring(0, 47) + "...");
+  }
+
   return (
     <div>
       {is_loading ? 
@@ -31,13 +39,13 @@ function Item() {
           <div className="flex flex-col items-center justify-center mt-8 px-8">
             <div className="w-fit">
               <p className="text-gray-700 dark:text-gray-400 text-lg font-semibold">
-                From this link was taken the screenshot 
+                Screenshot URL
                 <a 
                   href={screenshot.url}
                   target="_blank" 
                   rel="noopener noreferrer"
                   className="font-medium text-indigo-600 dark:text-indigo-500 hover:underline ml-2"
-                  > {screenshot.url}
+                  > {ShortenUrl(screenshot.url)}
                 </a>
               </p>
             </div>           

--- a/src/components/Screenshots.jsx
+++ b/src/components/Screenshots.jsx
@@ -18,7 +18,17 @@ function Screenshots() {
         Authorization: `Bearer ${token}`
       }
     })
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) {
+          if (response.status == 401) {
+            // The token is invalid
+            navigate("/login");
+          } else {
+            console.error('API error: ', response);
+          }
+        }
+        return response.json();
+      })
       .then((data) => {
         // Use the fetched screenshot data here
         setScreenshots(data);


### PR DESCRIPTION
This pull request shortens URLs that are too long to 50 characters and makes sure that authentication errors in the backend redirect you to the login page.